### PR TITLE
allow multiple callback handlers

### DIFF
--- a/tests/test.jmpress.js
+++ b/tests/test.jmpress.js
@@ -41,11 +41,22 @@ describe('Jmpress', function() {
 		 * test beforeChange
 		 */
 		it('should call a function before the slide has changed', function() {
-			var callback = jasmine.createSpy('beforeChange');
-			$('#jmpress').jmpress( 'beforeChange', callback );
-			expect( callback ).not.toHaveBeenCalled();
+			var callback1 = jasmine.createSpy('beforeChange1');
+			var callback2 = jasmine.createSpy('beforeChange2');
+			var callback3 = jasmine.createSpy('beforeChange3');
+			$.jmpress( 'beforeChange', callback3 );
+			$('#jmpress').jmpress( 'beforeChange', callback1 );
+			expect( callback1 ).not.toHaveBeenCalled();
+			expect( callback3 ).not.toHaveBeenCalled();
 			$('#jmpress').jmpress( 'next' );
-			expect( callback ).toHaveBeenCalled();
+			expect( callback1 ).toHaveBeenCalled();
+			expect( callback3 ).toHaveBeenCalled();
+			$('#jmpress').jmpress( 'beforeChange', callback2 );
+			expect( callback2 ).not.toHaveBeenCalled();
+			$('#jmpress').jmpress( 'next' );
+			expect( callback1.callCount ).toEqual(2);
+			expect( callback2.callCount ).toEqual(1);
+			expect( callback3.callCount ).toEqual(2);
 
 			// TODO: Test setting callbacks as param
 		});


### PR DESCRIPTION
here ist some small change.

This tweek allows multiple handlers to be attached to a callback/event. 
It also allows handlers to be attached before init is called. This will add a simple plugin feature. (More events are required to create useful plugins. I will add these if this commit is merged in)

Some sample code:

``` javascript
// some kind of plugin
$.jmpress( 'beforeChange', function( slide ) {
  // do some cool stuff
});
$("#jmpress").jmpress(...);
$("#jmpress").jmpress( 'beforeChange', function( slide ) {
  // Handler 1
});
$("#jmpress").jmpress( 'beforeChange', function( slide ) {
  // Handler 2
});
```
