### PR TITLE
Chrome on Android supports jmpress.js (out of the box)

### DIFF
--- a/src/components/core.js
+++ b/src/components/core.js
@@ -531,7 +531,8 @@
 		 */
 		function checkSupport() {
 			var ua = navigator.userAgent.toLowerCase();
-			var supported = ( ua.search(/(iphone)|(ipod)|(android)/) === -1 );
+			var supported = ( ua.search(/(iphone)|(ipod)|(android)/) === -1 ) 
+							|| (ua.search(/(chrome)/) !== -1);
 			return supported;
 		}
 


### PR DESCRIPTION
Chrome on Android works beautifully with jmpress.js provided the offsets and screen sizes are updated to match a smaller screen.

The only reason it wasn't working was because of the checkSupport() check for Android.
