### PR TITLE
Fixed deregistration of events

### DIFF
--- a/src/components/viewport.js
+++ b/src/components/viewport.js
@@ -139,6 +139,7 @@
 		$(this).jmpress("reselect", "zoom");
 	});
 	$.jmpress('afterDeinit', function( nil, eventData ) {
+		$(eventData.settings.fullscreen ? document : this).unbind(eventData.current.viewPortNamespace);
 		$(window).unbind(eventData.current.viewPortNamespace);
 	});
 	$.jmpress("setActive", function( step, eventData ) {


### PR DESCRIPTION
Events registered in the afterInit function (mousewheel, mousedown, ...)
aren't deregistered properly as the namespace is only used for 
deregistering on the window object.
