### PR TITLE
Update example/jqueryui/index.html

### DIFF
--- a/examples/jqueryui/index.html
+++ b/examples/jqueryui/index.html
@@ -60,7 +60,7 @@
   <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.9.2/jquery-ui.min.js"></script>
 
   <!-- jmpress - RECOMMENDED TO REPLACE WITH A LOCAL/HOSTED COPY -->
-  <script type="text/javascript" src="https://raw.github.com/jmpressjs/dist/master/jmpress.js"></script>
+  <script type="text/javascript" src="../../dist/jmpress.min.js"></script>
   <script type="text/javascript">
   // simple left to right template
   $.jmpress('template', 'simple', {


### PR DESCRIPTION
Avoid Chrome firing the below error:

Refused to execute script from 'https://raw.github.com/jmpressjs/dist/master/jmpress.js' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
