### PR TITLE
Fix for issue #154: https://github.com/jmpressjs/jmpress.js/issues/154

### DIFF
--- a/src/components/core.js
+++ b/src/components/core.js
@@ -14,7 +14,7 @@
 	 */
 	var pfx = (function () {
 		var style = document.createElement('dummy').style,
-			prefixes = 'Webkit Moz O ms Khtml'.split(' '),
+			prefixes = ['Webkit','Moz','O','ms','Khtml',''],
 			memory = {};
 		return function ( prop ) {
 			if ( typeof memory[ prop ] === "undefined" ) {
@@ -41,6 +41,12 @@
 		}
 		var index = 1 + name.substr(1).search(/[A-Z]/);
 		var prefix = name.substr(0, index).toLowerCase();
+
+        // If there's no prefix, use the name itself, don't attempt to prefix it with '-prefix-'.
+        if (prefix === '') {
+            return name;
+        }
+
 		var postfix = name.substr(index).toLowerCase();
 		return "-" + prefix + "-" + postfix;
 	}


### PR DESCRIPTION
Firefox has dropped support for their --moz-\* properties, and are instead using the standard ones (--moz-transform is now transform).
