### PR TITLE
Correctly quote Attribute Selectors

### DIFF
--- a/src/components/hash.js
+++ b/src/components/hash.js
@@ -6,7 +6,7 @@
 
 	'use strict';
 	var $jmpress = $.jmpress,
-		hashLink = "a[href^=#]";
+		hashLink = "a[href^='#']";
 
 	/* FUNCTIONS */
 	function randomString() {


### PR DESCRIPTION
Fixes jmpressjs/jmpress.js#185

(apologies for the line ending change, at EOF I'm doing this via the web editor on GitHub and it automatically added it -- I don't think I can correct it here)

See:
jquery/jquery@41f522a
jquery/jquery#2824
jquery/api.jquery.com#910
